### PR TITLE
internal apiとの通信をdefault 無効にする

### DIFF
--- a/lib/procon_bypass_man/bypass/usb_hid_logger.rb
+++ b/lib/procon_bypass_man/bypass/usb_hid_logger.rb
@@ -28,10 +28,12 @@ class ProconBypassMan::Bypass
         end
       end
 
-      ProconBypassMan.cache.fetch key: 'pressed_buttons_reporter', expires_in: 5 do
-        ProconBypassMan::ReportPressedButtonsJob.perform_async(
-          bypass_value.binary.to_procon_reader.to_hash
-        )
+      if ProconBypassMan.config.enable_reporting_pressed_buttons
+        ProconBypassMan.cache.fetch key: 'pressed_buttons_reporter', expires_in: 5 do
+          ProconBypassMan::ReportPressedButtonsJob.perform_async(
+            bypass_value.binary.to_procon_reader.to_hash
+          )
+        end
       end
     end
   end

--- a/lib/procon_bypass_man/configuration.rb
+++ b/lib/procon_bypass_man/configuration.rb
@@ -41,7 +41,7 @@ class ProconBypassMan::Configuration
   end
 
   attr_accessor :enable_critical_error_logging
-  attr_writer :verbose_bypass_log, :raw_setting
+  attr_writer :verbose_bypass_log, :raw_setting, :enable_reporting_pressed_buttons
 
   def root=(path)
     @root = path
@@ -153,5 +153,9 @@ class ProconBypassMan::Configuration
 
   def raw_setting
     @raw_setting ||= {}
+  end
+
+  def enable_reporting_pressed_buttons
+    @enable_reporting_pressed_buttons ||= false
   end
 end

--- a/spec/lib/procon_bypass_man/configuration_spec.rb
+++ b/spec/lib/procon_bypass_man/configuration_spec.rb
@@ -58,4 +58,16 @@ describe ProconBypassMan::Configuration do
       end
     end
   end
+
+  describe '#enable_reporting_pressed_buttons' do
+    let(:config) { described_class.new }
+    it 'default false' do
+      expect(config.enable_reporting_pressed_buttons).to eq(false)
+    end
+
+    it do
+      config.enable_reporting_pressed_buttons = true
+      expect(config.enable_reporting_pressed_buttons).to eq(true)
+    end
+  end
 end

--- a/spec/lib/procon_bypass_man_spec.rb
+++ b/spec/lib/procon_bypass_man_spec.rb
@@ -45,6 +45,8 @@ describe ProconBypassMan do
       :digest_path,
       :raw_setting,
       :raw_setting=,
+      :enable_reporting_pressed_buttons,
+      :enable_reporting_pressed_buttons=,
     ].each do |me|
       it "has config.#{me} method" do
         expect(described_class.config.respond_to?(me)).to eq(true)


### PR DESCRIPTION
単体で`procon_bypass_man`を起動すると以下のエラーが出続けるため、出ないようにする
`Failed to open TCP connection to localhost:9090 (Connection refused - connect(2) for "localhost" port 9090)`