### PR TITLE
v2マクロで定義のないボタンを使用したら無視する

### DIFF
--- a/spec/lib/procon_bypass_man/procon/macro_builder_spec.rb
+++ b/spec/lib/procon_bypass_man/procon/macro_builder_spec.rb
@@ -26,29 +26,35 @@ describe ProconBypassMan::Procon::MacroBuilder do
     end
 
     describe 'v2 format' do
+      describe 'toggle + 存在しないボタン' do
+        it do
+          expect(described_class.new([:toggle_v]).build).to eq([:none])
+        end
+      end
+
       describe 'toggle' do
         it do
-          expect(described_class.new([:toggle_r]).build).to eq([:r, :none])
+          expect(described_class.new([:toggle_a]).build).to eq([:a, :none])
         end
         it do
-          expect(described_class.new([:toggle_r, :toggle_b]).build).to eq([:r, :none, :b, :none])
+          expect(described_class.new([:toggle_a, :toggle_b]).build).to eq([:a, :none, :b, :none])
         end
         it do
-          expect(described_class.new([:a, :toggle_r, :sl, :toggle_b, :b]).build).to eq([:a, :r, :none, :sl, :b, :none, :b])
+          expect(described_class.new([:a, :toggle_b, :sl, :toggle_b, :b]).build).to eq([:a, :b, :none, :sl, :b, :none, :b])
         end
       end
 
       describe 'toggle_x_for_2sec' do
         it do
-          expect(described_class.new([:toggle_r_for_2sec]).build).to eq(
-            [{ continue_for: 2, steps: [:r, :none] }]
+          expect(described_class.new([:toggle_a_for_2sec]).build).to eq(
+            [{ continue_for: 2, steps: [:a, :none] }]
           )
         end
         it do
-          expect(described_class.new([:toggle_r, :toggle_r_for_3sec]).build).to eq(
-            [ :r,
+          expect(described_class.new([:toggle_b, :toggle_a_for_3sec]).build).to eq(
+            [ :b,
               :none,
-              { continue_for: 3, steps: [:r, :none] }
+              { continue_for: 3, steps: [:a, :none] }
             ]
           )
         end

--- a/spec/lib/procon_bypass_man/procon_spec.rb
+++ b/spec/lib/procon_bypass_man/procon_spec.rb
@@ -240,6 +240,35 @@ describe ProconBypassMan::Procon do
     context 'v2' do
       context 'y, bを押しているとき' do
         let(:data) { "30778105800099277344e86b0a7909f4f5a8f4b500c5ff8dff6c09cdf5b8f49a00c5ff92ff6a0979f5eef46500d5ff9bff000000000000000000000000000000" }
+        context '定義にないボタンを使うとき' do
+          before do
+            ProconBypassMan.buttons_setting_configure do
+              prefix_keys_for_changing_layer [:zr]
+              layer :up do
+                open_macro :single, steps: [:pressing_v_for_2sec], if_pressed: [:y, :b]
+              end
+            end
+          end
+          it 'そのボタンは無視する' do
+            expect(ProconBypassMan::Procon::MacroRegistry.plugins[:single].call).to eq(
+              [{:continue_for=>2, :steps=>[]}]
+            )
+
+            procon = ProconBypassMan::Procon.new(binary)
+            expect(procon.pressed_y?).to eq(true)
+            expect(procon.pressed_b?).to eq(true)
+            expect(procon.pressed_thumbr?).to eq(false)
+            procon.apply!
+
+            procon = ProconBypassMan::Procon.new(procon.to_binary)
+            expect(procon.pressed_thumbr?).to eq(false)
+            expect(procon.pressed_zr?).to eq(false)
+            procon.apply!
+          end
+        end
+      end
+      context 'y, bを押しているとき' do
+        let(:data) { "30778105800099277344e86b0a7909f4f5a8f4b500c5ff8dff6c09cdf5b8f49a00c5ff92ff6a0979f5eef46500d5ff9bff000000000000000000000000000000" }
         before do
           ProconBypassMan.buttons_setting_configure do
             prefix_keys_for_changing_layer [:zr]


### PR DESCRIPTION
fix https://github.com/splaplapla/procon_bypass_man/issues/79