### PR TITLE
ログファイルは1MBでローテーションし、1世代のみを残す

### DIFF
--- a/lib/procon_bypass_man/configuration.rb
+++ b/lib/procon_bypass_man/configuration.rb
@@ -104,7 +104,7 @@ class ProconBypassMan::Configuration
 
   def error_logger
     if enable_critical_error_logging
-      @error_logger ||= Logger.new("#{ProconBypassMan.root}/error.log", 5, 1024 * 1024 * 10)
+      @error_logger ||= Logger.new("#{ProconBypassMan.root}/error.log", 1, 1024 * 1024 * 1)
     else
       Logger.new(File.open("/dev/null"))
     end

--- a/project_template/app.rb
+++ b/project_template/app.rb
@@ -19,7 +19,7 @@ end
 
 ProconBypassMan.configure do |config|
   config.root = File.expand_path(__dir__)
-  config.logger = Logger.new("#{ProconBypassMan.root}/app.log", 5, 1024 * 1024 * 10)
+  config.logger = Logger.new("#{ProconBypassMan.root}/app.log", 1, 1024 * 1024 * 1)
   config.logger.level = :debug
 
   # バイパスするログを全部app.logに流すか


### PR DESCRIPTION
バージョンアップしてるとディスクを使いがち。残しても見ないので、、、