### PR TITLE
入力表示で使うsimple httpサーバを実装する

### DIFF
--- a/lib/procon_bypass_man/procon_display.rb
+++ b/lib/procon_bypass_man/procon_display.rb
@@ -4,4 +4,7 @@ module ProconBypassMan::ProconDisplay
 end
 
 require "procon_bypass_man/procon_display/server"
+require "procon_bypass_man/procon_display/server_app"
 require "procon_bypass_man/procon_display/status"
+require "procon_bypass_man/procon_display/http_response"
+require "procon_bypass_man/procon_display/http_request"

--- a/lib/procon_bypass_man/procon_display/http_request.rb
+++ b/lib/procon_bypass_man/procon_display/http_request.rb
@@ -1,0 +1,11 @@
+module ProconBypassMan::ProconDisplay
+  class HttpResponse
+    def initialize(body, status: )
+      @body = body
+      @status = status
+    end
+
+    def to_s
+    end
+  end
+end

--- a/lib/procon_bypass_man/procon_display/http_request.rb
+++ b/lib/procon_bypass_man/procon_display/http_request.rb
@@ -18,7 +18,7 @@ module ProconBypassMan::ProconDisplay
     end
 
     def path
-      request_method_and_path = @headers.detect { |key, value| key.start_with?("GET") }.first
+      request_method_and_path = @headers.detect { |key, _value| key.start_with?("GET") }.first
       if request_method_and_path =~ /(?:GET) ([^ ]+)/ && (path = $1)
         return path
       end

--- a/lib/procon_bypass_man/procon_display/http_request.rb
+++ b/lib/procon_bypass_man/procon_display/http_request.rb
@@ -1,11 +1,31 @@
 module ProconBypassMan::ProconDisplay
-  class HttpResponse
-    def initialize(body, status: )
-      @body = body
-      @status = status
+  # NOTE Support GET only
+  class HttpRequest
+    def self.parse(conn)
+      headers = {}
+      loop do
+        line = conn.gets("\n")&.strip
+        break if line.nil? || line.strip.empty?
+        key, value = line.split(/:\s/, 2)
+        headers[key] = value
+      end
+
+      new(headers)
     end
 
-    def to_s
+    def initialize(headers)
+      @headers = headers
+    end
+
+    def path
+      request_method_and_path = @headers.detect { |key, value| key.start_with?("GET") }.first
+      if request_method_and_path =~ /(?:GET) ([^ ]+)/ && (path = $1)
+        return path
+      end
+    end
+
+    def to_hash
+      { "PATH" => path }
     end
   end
 end

--- a/lib/procon_bypass_man/procon_display/http_response.rb
+++ b/lib/procon_bypass_man/procon_display/http_response.rb
@@ -11,6 +11,7 @@ module ProconBypassMan::ProconDisplay
         HTTP/1.1 #{@status}
         Content-Length: #{@body&.bytes&.size || 0}
         Content-Type: #{@format}
+        Connection: close
 
         #{@body}
       EOH

--- a/lib/procon_bypass_man/procon_display/http_response.rb
+++ b/lib/procon_bypass_man/procon_display/http_response.rb
@@ -1,0 +1,22 @@
+module ProconBypassMan::ProconDisplay
+  class HttpRequest
+    def self.parse(conn)
+      headers = {}
+      loop do
+        line = conn.gets("\n")&.strip
+        break if line.nil? || line.strip.empty?
+        key, value = line.split(/:\s/, 2)
+        headers[key] = value
+      end
+
+      new(headers)
+    end
+
+    def initialize(headers)
+      @headers = headers
+    end
+
+    def path
+    end
+  end
+end

--- a/lib/procon_bypass_man/procon_display/http_response.rb
+++ b/lib/procon_bypass_man/procon_display/http_response.rb
@@ -11,6 +11,7 @@ module ProconBypassMan::ProconDisplay
         HTTP/1.1 #{@status}
         Content-Length: #{@body&.bytes&.size || 0}
         Content-Type: #{@format}
+        Access-Control-Allow-Origin: *
         Connection: close
 
         #{@body}

--- a/lib/procon_bypass_man/procon_display/http_response.rb
+++ b/lib/procon_bypass_man/procon_display/http_response.rb
@@ -1,27 +1,19 @@
 module ProconBypassMan::ProconDisplay
-  # NOTE Support GET only
-  class HttpRequest
-    def self.parse(conn)
-      headers = {}
-      loop do
-        line = conn.gets("\n")&.strip
-        break if line.nil? || line.strip.empty?
-        key, value = line.split(/:\s/, 2)
-        headers[key] = value
-      end
-
-      new(headers)
+  class HttpResponse
+    def initialize(body, status: , format: "text/json")
+      @body = body&.to_json
+      @status = status
+      @format = format
     end
 
-    def initialize(headers)
-      @headers = headers
-    end
+    def to_s
+      <<~EOH
+        HTTP/1.1 #{@status}
+        Content-Length: #{@body&.bytes&.size || 0}
+        Content-Type: #{@format}
 
-    def path
-      request_method_and_path = @headers.detect { |key, value| key.start_with?("GET") }.first
-      if request_method_and_path =~ /(?:GET) ([^ ]+)/ && (path = $1)
-        return path
-      end
+        #{@body}
+      EOH
     end
   end
 end

--- a/lib/procon_bypass_man/procon_display/http_response.rb
+++ b/lib/procon_bypass_man/procon_display/http_response.rb
@@ -1,4 +1,5 @@
 module ProconBypassMan::ProconDisplay
+  # NOTE Support GET only
   class HttpRequest
     def self.parse(conn)
       headers = {}
@@ -17,6 +18,10 @@ module ProconBypassMan::ProconDisplay
     end
 
     def path
+      request_method_and_path = @headers.detect { |key, value| key.start_with?("GET") }.first
+      if request_method_and_path =~ /(?:GET) ([^ ]+)/ && (path = $1)
+        return path
+      end
     end
   end
 end

--- a/lib/procon_bypass_man/procon_display/server.rb
+++ b/lib/procon_bypass_man/procon_display/server.rb
@@ -12,16 +12,15 @@ class ProconBypassMan::ProconDisplay::Server
   def start_with_foreground
     server = TCPServer.new('0.0.0.0', PORT)
     loop do
-      socket = server.accept
-      socket.write(response)
-      socket.close
+      conn = server.accept
+      response = App.new(
+        HttpRequest.parse(conn).to_hash
+      ).call
+      conn.write(response)
+      conn.close
     end
   rescue Errno::EADDRINUSE => e
     ProconBypassMan::SendErrorCommand.execute(error: e)
-  end
-
-  def response
-    ProconBypassMan::ProconDisplay::Status.instance.current.to_json
   end
 end
 

--- a/lib/procon_bypass_man/procon_display/server.rb
+++ b/lib/procon_bypass_man/procon_display/server.rb
@@ -23,9 +23,3 @@ class ProconBypassMan::ProconDisplay::Server
     ProconBypassMan::SendErrorCommand.execute(error: e)
   end
 end
-
-# client例
-# require 'socket'
-# TCPSocket.open('127.0.0.1', 9900){ |s|
-#   print s.read
-# }

--- a/lib/procon_bypass_man/procon_display/server.rb
+++ b/lib/procon_bypass_man/procon_display/server.rb
@@ -1,25 +1,27 @@
 require 'socket'
 
-class ProconBypassMan::ProconDisplay::Server
-  PORT = 9900
+module ProconBypassMan::ProconDisplay
+  class Server
+    PORT = 9900
 
-  def self.start!
-    Thread.new do
-      new.start_with_foreground
+    def self.start!
+      Thread.new do
+        new.start_with_foreground
+      end
     end
-  end
 
-  def start_with_foreground
-    server = TCPServer.new('0.0.0.0', PORT)
-    loop do
-      conn = server.accept
-      response = App.new(
-        HttpRequest.parse(conn).to_hash
-      ).call
-      conn.write(response)
-      conn.close
+    def start_with_foreground
+      server = TCPServer.new('0.0.0.0', PORT)
+      loop do
+        conn = server.accept
+        response = ServerApp.new(
+          HttpRequest.parse(conn).to_hash
+        ).call
+        conn.write(response)
+        conn.close
+      end
+    rescue Errno::EADDRINUSE => e
+      ProconBypassMan::SendErrorCommand.execute(error: e)
     end
-  rescue Errno::EADDRINUSE => e
-    ProconBypassMan::SendErrorCommand.execute(error: e)
   end
 end

--- a/lib/procon_bypass_man/procon_display/server.rb
+++ b/lib/procon_bypass_man/procon_display/server.rb
@@ -10,10 +10,13 @@ module ProconBypassMan::ProconDisplay
       end
     end
 
+    def initialize
+      @server = TCPServer.new('0.0.0.0', PORT)
+    end
+
     def start_with_foreground
-      server = TCPServer.new('0.0.0.0', PORT)
       loop do
-        conn = server.accept
+        conn = @server.accept
         response = ServerApp.new(
           HttpRequest.parse(conn).to_hash
         ).call
@@ -22,6 +25,8 @@ module ProconBypassMan::ProconDisplay
       end
     rescue Errno::EADDRINUSE => e
       ProconBypassMan::SendErrorCommand.execute(error: e)
+    rescue
+      retry
     end
   end
 end

--- a/lib/procon_bypass_man/procon_display/server_app.rb
+++ b/lib/procon_bypass_man/procon_display/server_app.rb
@@ -7,16 +7,11 @@ module ProconBypassMan::ProconDisplay
     def call
       case @env["PATH"]
       when "/"
+        response = ProconBypassMan::ProconDisplay::Status.instance.current.to_json
         HttpResponse.new(response, status: 200).to_s
       else
         HttpResponse.new(nil, status: 404).to_s
       end
-    end
-
-    private
-
-    def response
-      ProconBypassMan::ProconDisplay::Status.instance.current.to_json
     end
   end
 end

--- a/lib/procon_bypass_man/procon_display/server_app.rb
+++ b/lib/procon_bypass_man/procon_display/server_app.rb
@@ -1,0 +1,22 @@
+module ProconBypassMan::ProconDisplay
+  class ServerApp
+    def initialize(env)
+      @env = env
+    end
+
+    def call
+      case @env["PATH"]
+      when "/"
+        HttpResponse.new(response, status: 200).to_s
+      else
+        HttpResponse.new(nil, status: 404).to_s
+      end
+    end
+
+    private
+
+    def response
+      ProconBypassMan::ProconDisplay::Status.instance.current.to_json
+    end
+  end
+end

--- a/lib/procon_bypass_man/procon_display/server_app.rb
+++ b/lib/procon_bypass_man/procon_display/server_app.rb
@@ -7,7 +7,7 @@ module ProconBypassMan::ProconDisplay
     def call
       case @env["PATH"]
       when "/"
-        response = ProconBypassMan::ProconDisplay::Status.instance.current.to_json
+        response = ProconBypassMan::ProconDisplay::Status.instance.current
         HttpResponse.new(response, status: 200).to_s
       else
         HttpResponse.new(nil, status: 404).to_s

--- a/spec/lib/procon_bypass_man/procon_display/http_request_spec.rb
+++ b/spec/lib/procon_bypass_man/procon_display/http_request_spec.rb
@@ -17,7 +17,7 @@ accept: */*
       end
 
       it do
-        expect(subject.path).to eq("/health_check")
+        expect(subject.to_hash).to eq({ "PATH" => "/health_check" })
       end
     end
 
@@ -32,6 +32,10 @@ GET / HTTP/1.1
 
       it do
         expect(subject.path).to eq("/")
+      end
+
+      it do
+        expect(subject.to_hash).to eq({ "PATH" => "/" })
       end
     end
   end

--- a/spec/lib/procon_bypass_man/procon_display/http_request_spec.rb
+++ b/spec/lib/procon_bypass_man/procon_display/http_request_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+describe ProconBypassMan::ProconDisplay::HttpRequest do
+  describe '.parse' do
+    subject { described_class.parse(io) }
+
+    context 'ヘッダーがモリモリ' do
+      let(:io) { StringIO.new(raw_http_request) }
+      let(:raw_http_request) do
+        <<~EOH
+GET /health_check HTTP/1.1
+Host: example.com
+user-agent: curl/7.79.1
+accept: */*
+
+        EOH
+      end
+
+      it do
+        expect(subject.path).to eq("/health_check")
+      end
+    end
+
+    context 'シンプル' do
+      let(:io) { StringIO.new(raw_http_request) }
+      let(:raw_http_request) do
+        <<~EOH
+GET / HTTP/1.1
+
+        EOH
+      end
+
+      it do
+        expect(subject.path).to eq("/")
+      end
+    end
+  end
+end

--- a/spec/lib/procon_bypass_man/procon_display/http_response_spec.rb
+++ b/spec/lib/procon_bypass_man/procon_display/http_response_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+
+describe ProconBypassMan::ProconDisplay::HttpResponse do
+  describe '#to_s' do
+    subject { described_class.new(body, status: status).to_s }
+
+    context 'provide { a: 2 } and 200' do
+      let(:body) { { a: 2 } }
+      let(:status) { 200 }
+
+      it do
+        expect(subject).to eq <<~EOH
+          HTTP/1.1 200
+          Content-Length: 7
+          Content-Type: text/json
+
+          #{body.to_json}
+        EOH
+      end
+    end
+
+    context 'provide {} and 404' do
+      let(:body) { {} }
+      let(:status) { 404 }
+
+      it do
+        expect(subject).to eq <<~EOH
+          HTTP/1.1 404
+          Content-Length: 2
+          Content-Type: text/json
+
+          {}
+        EOH
+      end
+    end
+
+    context 'provide {} and 200' do
+      let(:body) { {} }
+      let(:status) { 200 }
+
+      it do
+        expect(subject).to eq <<~EOH
+          HTTP/1.1 200
+          Content-Length: 2
+          Content-Type: text/json
+
+          {}
+        EOH
+      end
+    end
+
+    context 'provide nil and 404' do
+      let(:body) { nil }
+      let(:status) { 200 }
+
+      it do
+        expect(subject).to eq <<~EOH
+          HTTP/1.1 200
+          Content-Length: 0
+          Content-Type: text/json
+
+
+        EOH
+      end
+    end
+  end
+end

--- a/spec/lib/procon_bypass_man/procon_display/http_response_spec.rb
+++ b/spec/lib/procon_bypass_man/procon_display/http_response_spec.rb
@@ -13,6 +13,7 @@ describe ProconBypassMan::ProconDisplay::HttpResponse do
           HTTP/1.1 200
           Content-Length: 7
           Content-Type: text/json
+          Access-Control-Allow-Origin: *
           Connection: close
 
           #{body.to_json}
@@ -29,6 +30,7 @@ describe ProconBypassMan::ProconDisplay::HttpResponse do
           HTTP/1.1 404
           Content-Length: 2
           Content-Type: text/json
+          Access-Control-Allow-Origin: *
           Connection: close
 
           {}
@@ -45,6 +47,7 @@ describe ProconBypassMan::ProconDisplay::HttpResponse do
           HTTP/1.1 200
           Content-Length: 2
           Content-Type: text/json
+          Access-Control-Allow-Origin: *
           Connection: close
 
           {}
@@ -61,6 +64,7 @@ describe ProconBypassMan::ProconDisplay::HttpResponse do
           HTTP/1.1 200
           Content-Length: 0
           Content-Type: text/json
+          Access-Control-Allow-Origin: *
           Connection: close
 
 

--- a/spec/lib/procon_bypass_man/procon_display/http_response_spec.rb
+++ b/spec/lib/procon_bypass_man/procon_display/http_response_spec.rb
@@ -13,6 +13,7 @@ describe ProconBypassMan::ProconDisplay::HttpResponse do
           HTTP/1.1 200
           Content-Length: 7
           Content-Type: text/json
+          Connection: close
 
           #{body.to_json}
         EOH
@@ -28,6 +29,7 @@ describe ProconBypassMan::ProconDisplay::HttpResponse do
           HTTP/1.1 404
           Content-Length: 2
           Content-Type: text/json
+          Connection: close
 
           {}
         EOH
@@ -43,6 +45,7 @@ describe ProconBypassMan::ProconDisplay::HttpResponse do
           HTTP/1.1 200
           Content-Length: 2
           Content-Type: text/json
+          Connection: close
 
           {}
         EOH
@@ -58,6 +61,7 @@ describe ProconBypassMan::ProconDisplay::HttpResponse do
           HTTP/1.1 200
           Content-Length: 0
           Content-Type: text/json
+          Connection: close
 
 
         EOH

--- a/spec/lib/procon_bypass_man/procon_display/server_app_spec.rb
+++ b/spec/lib/procon_bypass_man/procon_display/server_app_spec.rb
@@ -18,6 +18,7 @@ describe ProconBypassMan::ProconDisplay::ServerApp do
           HTTP/1.1 200
           Content-Length: 9
           Content-Type: text/json
+          Access-Control-Allow-Origin: *
           Connection: close
 
           #{{a: 123 }.to_json}
@@ -35,6 +36,7 @@ describe ProconBypassMan::ProconDisplay::ServerApp do
           HTTP/1.1 200
           Content-Length: 2
           Content-Type: text/json
+          Access-Control-Allow-Origin: *
           Connection: close
 
           {}
@@ -51,6 +53,7 @@ describe ProconBypassMan::ProconDisplay::ServerApp do
           HTTP/1.1 404
           Content-Length: 0
           Content-Type: text/json
+          Access-Control-Allow-Origin: *
           Connection: close
 
 

--- a/spec/lib/procon_bypass_man/procon_display/server_app_spec.rb
+++ b/spec/lib/procon_bypass_man/procon_display/server_app_spec.rb
@@ -18,6 +18,7 @@ describe ProconBypassMan::ProconDisplay::ServerApp do
           HTTP/1.1 200
           Content-Length: 9
           Content-Type: text/json
+          Connection: close
 
           #{{a: 123 }.to_json}
           EOH
@@ -34,6 +35,7 @@ describe ProconBypassMan::ProconDisplay::ServerApp do
           HTTP/1.1 200
           Content-Length: 2
           Content-Type: text/json
+          Connection: close
 
           {}
           EOH
@@ -49,6 +51,7 @@ describe ProconBypassMan::ProconDisplay::ServerApp do
           HTTP/1.1 404
           Content-Length: 0
           Content-Type: text/json
+          Connection: close
 
 
         EOH

--- a/spec/lib/procon_bypass_man/procon_display/server_app_spec.rb
+++ b/spec/lib/procon_bypass_man/procon_display/server_app_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+
+describe ProconBypassMan::ProconDisplay::ServerApp do
+  describe '#call' do
+    subject { described_class.new(env).call  }
+
+
+    context '/' do
+      let(:env) { { "PATH" => "/" } }
+
+      context 'has value status' do
+        before do
+          ProconBypassMan::ProconDisplay::Status.instance.current = { a: 123 }
+        end
+
+        it do
+          expect(subject).to eq <<~EOH
+          HTTP/1.1 200
+          Content-Length: 9
+          Content-Type: text/json
+
+          #{{a: 123 }.to_json}
+          EOH
+        end
+      end
+
+      context 'empty status' do
+        before do
+          ProconBypassMan::ProconDisplay::Status.instance.current = nil
+        end
+
+        it do
+          expect(subject).to eq <<~EOH
+          HTTP/1.1 200
+          Content-Length: 2
+          Content-Type: text/json
+
+          {}
+          EOH
+        end
+      end
+    end
+
+    context '/foo' do
+      let(:env) { { "PATH" => "/foo" } }
+
+      it do
+        expect(subject).to eq <<~EOH
+          HTTP/1.1 404
+          Content-Length: 0
+          Content-Type: text/json
+
+
+        EOH
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/splaplapla/procon_bypass_man/issues/138

TCP通信でブラウザから呼び出す想定をしていたけど、ブラウザにはTCP通信ができなかった。
仕方がないのでHTTPで返す。

https://techracho.bpsinc.jp/hachi8833/2021_10_22/112296


```
$ curl -i http://192.168.50.122:9900/
HTTP/1.1 200
Content-Length: 98
Content-Type: text/json
Connection: close

{"left_analog_stick":{"x":33,"y":-68},"left_analog_stick_by_abs":{"x":2133,"y":1932},"buttons":[]}

$ curl -i http://192.168.50.122:9900/a
HTTP/1.1 404
Content-Length: 0
Content-Type: text/json
Connection: close
```