### PR TITLE
起動時のエラー処理でrequire 'fileutils'を呼ぶ

### DIFF
--- a/project_template/app.rb
+++ b/project_template/app.rb
@@ -12,6 +12,7 @@ rescue Bundler::Source::Git::GitCommandError => e
   # install中に強制終了するとgitの管理ファイルが不正状態になり、次のエラーが起きるので発生したらcache directoryを削除する
   #"Git error: command `git fetch --force --quiet --tags https://github.com/splaplapla/procon_bypass_man refs/heads/\\*:refs/heads/\\*` in directory /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/cache/bundler/git/procon_bypass_man-ae4c9016d76b667658c8ba66f3bbd2eebf2656af has failed.\n\nIf this error persists you could try removing the cache directory '/home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/cache/bundler/git/procon_bypass_man-ae4c9016d76b667658c8ba66f3bbd2eebf2656af'"
   if /try removing the cache directory '([^']+)'/ =~ e.message
+    require 'fileutils'
     FileUtils.rm_rf($1)
     retry
   end


### PR DESCRIPTION
いらないと思ったんだけど。

```
May 25 23:41:38 raspberrypi2 bash[22710]: /usr/share/pbm/current/app.rb:16:in `rescue in <main>': uninitialized constant FileUtils (NameError)
May 25 23:41:38 raspberrypi2 bash[22710]: Did you mean?  FileTest
May 25 23:41:38 raspberrypi2 bash[22710]:         from /usr/share/pbm/current/app.rb:5:in `<main>'
May 25 23:41:38 raspberrypi2 bash[22710]: /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.20/lib/bundler/source/git/git_proxy.rb:175:in `git': Git error: command `git fetch --force --quiet --tags https://github.com/splaplapla/procon_bypass_man refs/heads/\\*:refs/heads/\\*` in directory /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/cache/bundler/git/procon_bypass_man-ae4c9016d76b667658c8ba66f3bbd2eebf2656af has failed. (Bundler::Source::Git::GitCommandError)
May 25 23:41:38 raspberrypi2 bash[22710]: If this error persists you could try removing the cache directory '/home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/cache/bundler/git/procon_bypass_man-ae4c9016d76b667658c8ba66f3bbd2eebf2656af'
May 25 23:41:38 raspberrypi2 bash[22710]:         from /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.20/lib/bundler/source/git/git_proxy.rb:162:in `block in git_retry'
May 25 23:41:38 raspberrypi2 bash[22710]:         from /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.20/lib/bundler/retry.rb:40:in `run'
May 25 23:41:38 raspberrypi2 bash[22710]:         from /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.20/lib/bundler/retry.rb:30:in `attempt'
May 25 23:41:38 raspberrypi2 bash[22710]:         from /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.20/lib/bundler/source/git/git_proxy.rb:161:in `git_retry'
May 25 23:41:38 raspberrypi2 bash[22710]:         from /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.20/lib/bundler/source/git/git_proxy.rb:106:in `block in checkout'
May 25 23:41:38 raspberrypi2 bash[22710]:         from /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.20/lib/bundler/source/git/git_proxy.rb:218:in `with_path'
May 25 23:41:38 raspberrypi2 bash[22710]:         from /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.20/lib/bundler/source/git/git_proxy.rb:105:in `checkout'
May 25 23:41:38 raspberrypi2 bash[22710]:         from /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.20/lib/bundler/source/git.rb:310:in `fetch'
May 25 23:41:38 raspberrypi2 bash[22710]:         from /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.20/lib/bundler/source/git.rb:164:in `specs'
```