### PR TITLE
ruby2.5で動くようにする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,7 @@ build_jobs: &build_jobs
       matrix:
         parameters:
           ruby-version:
+            - "2.5.5"
             - "3.0.1"
             - "3.0.2"
             - "3.1.1"
@@ -121,6 +122,7 @@ build_jobs: &build_jobs
       matrix:
         parameters:
           ruby-version:
+            - "2.5.5"
             - "3.0.1"
             - "3.0.2"
             - "3.1.1"
@@ -128,6 +130,7 @@ build_jobs: &build_jobs
       matrix:
         parameters:
           ruby-version:
+            - "2.5.5"
             - "3.0.1"
             - "3.0.2"
             - "3.1.1"
@@ -146,6 +149,7 @@ build_jobs: &build_jobs
       matrix:
         parameters:
           ruby-version:
+            - "2.5.5"
             - "3.0.1"
             - "3.0.2"
             - "3.1.1"

--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,11 @@ gem "rspec"
 gem "pry"
 gem "timecop"
 gem "rubocop", require: false
-gem "steep", require: false
-gem 'typeprof', require: false
-gem 'rbs', require: false
 gem "sinatra", require: false
 gem "webrick", require: false
+
+if Gem::Version.new(RUBY_VERSION) > Gem::Version.new("2.6.0")
+  gem 'typeprof', require: false
+  gem 'rbs', require: false
+  gem "steep", require: false
+end

--- a/procon_bypass_man.gemspec
+++ b/procon_bypass_man.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = spec.summary
   spec.homepage      = "https://github.com/splaplapla/procon_bypass_man"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 3.0.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
以前は、2.5だと接続処理が進まなかったけど、今は動くようになっているはず。
それと、rbenvを依存にしたくなくて、aptで入れたrubyでも動いたほうがドキュメントが薄くなっていい。