### PR TITLE
pbm_webに関する記述を削除する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## unrelease
 * project_template/app.rbを動的に生成する仕組みを追加しました
+* pbm_webに関する記述を削除しました
 
 ## [0.2.1] - 2022-05-29
 - 入力表示機能を提供するSwitchProconInputViewerに対応しました

--- a/project_template/README.md
+++ b/project_template/README.md
@@ -1,6 +1,5 @@
 # Project Template
 * これらは https://github.com/splaplapla/pbmenv がinstallするときに配備するファイルです
-* pbm_webはオプショナルです
 
 ## systemdを使ってサービスに登録する方法
 systemctl enableした後は、次回のOS起動時にserviceも自動起動します
@@ -8,13 +7,9 @@ systemctl enableした後は、次回のOS起動時にserviceも自動起動し�
 * pbm
   * sudo systemctl link /usr/share/pbm/current/systemd_units/pbm.service
   * sudo systemctl enable pbm.service
-* pbm_web
-  * sudo systemctl link /usr/share/pbm/current/systemd_units/pbm_web.service
-  * sudo systemctl enable pbm_web.service
 
 ## systemdを使ってサービスから解除する方法
 * sudo systemctl disable pbm.service
-* sudo systemctl disable pbm_web.service
 
 ### CheatSheet
 * systemctl daemon-reload


### PR DESCRIPTION
pbm_webのメンテナンスできていないのと、 https://pbm-cloud.herokuapp.com/ の方に機能を移植しつつあるので、、、