### PR TITLE
起動スクリプトが最新バージョンのディレクトリを削除してしまうことがあるのを修正する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## unrelease
 * project_template/app.rbを動的に生成する仕組みを追加しました
 * pbm_webに関する記述を削除しました
+* 起動スクリプト(app.rb) がたまに意図せず /usr/share/pbm/current を削除してしまう不具合を修正しました
 
 ## [0.2.1] - 2022-05-29
 - 入力表示機能を提供するSwitchProconInputViewerに対応しました

--- a/project_template/app.rb
+++ b/project_template/app.rb
@@ -2,20 +2,31 @@
 
 require 'bundler/inline'
 
+retry_count_on_git_command_error = 0
 begin
+  if retry_count_on_git_command_error > 3
+    STDOUT.puts "Stopped the procon_bypass_man program because could not download any source codes."
+    exit 1
+  end
+
   gemfile do
     source 'https://rubygems.org'
     git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
     gem 'procon_bypass_man', '0.2.1'
   end
 rescue Bundler::Source::Git::GitCommandError => e
+  retry_count_on_git_command_error =+ 1
+  sleep(5) # サービスの起動順によっては、まだoffline状態なので待機する
+
   # install中に強制終了するとgitの管理ファイルが不正状態になり、次のエラーが起きるので発生したらcache directoryを削除する
   #"Git error: command `git fetch --force --quiet --tags https://github.com/splaplapla/procon_bypass_man refs/heads/\\*:refs/heads/\\*` in directory /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/cache/bundler/git/procon_bypass_man-ae4c9016d76b667658c8ba66f3bbd2eebf2656af has failed.\n\nIf this error persists you could try removing the cache directory '/home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/cache/bundler/git/procon_bypass_man-ae4c9016d76b667658c8ba66f3bbd2eebf2656af'"
-  if /try removing the cache directory '([^']+)'/ =~ e.message
+  if /try removing the cache directory '([^']+)'/ =~ e.message && $1&.start_with?('/home/pi/.rbenv')
     require 'fileutils'
     FileUtils.rm_rf($1)
-    retry
+    STDOUT.puts "Deleted #{$1}"
   end
+
+  retry
 end
 
 ProconBypassMan.configure do |config|

--- a/project_template/app.rb
+++ b/project_template/app.rb
@@ -4,7 +4,7 @@ require 'bundler/inline'
 
 retry_count_on_git_command_error = 0
 begin
-  if retry_count_on_git_command_error > 3
+  if retry_count_on_git_command_error > 10
     STDOUT.puts "Stopped the procon_bypass_man program because could not download any source codes."
     exit 1
   end
@@ -15,7 +15,7 @@ begin
     gem 'procon_bypass_man', '0.2.1'
   end
 rescue Bundler::Source::Git::GitCommandError => e
-  retry_count_on_git_command_error =+ 1
+  retry_count_on_git_command_error = retry_count_on_git_command_error + 1
   sleep(5) # サービスの起動順によっては、まだoffline状態なので待機する
 
   # install中に強制終了するとgitの管理ファイルが不正状態になり、次のエラーが起きるので発生したらcache directoryを削除する

--- a/project_template/app.rb.erb
+++ b/project_template/app.rb.erb
@@ -2,20 +2,31 @@
 
 require 'bundler/inline'
 
+retry_count_on_git_command_error = 0
 begin
+  if retry_count_on_git_command_error > 3
+    STDOUT.puts "Stopped the procon_bypass_man program because could not download any source codes."
+    exit 1
+  end
+
   gemfile do
     source 'https://rubygems.org'
     git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
     gem 'procon_bypass_man', '0.2.1'
   end
 rescue Bundler::Source::Git::GitCommandError => e
+  retry_count_on_git_command_error =+ 1
+  sleep(5) # サービスの起動順によっては、まだoffline状態なので待機する
+
   # install中に強制終了するとgitの管理ファイルが不正状態になり、次のエラーが起きるので発生したらcache directoryを削除する
   #"Git error: command `git fetch --force --quiet --tags https://github.com/splaplapla/procon_bypass_man refs/heads/\\*:refs/heads/\\*` in directory /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/cache/bundler/git/procon_bypass_man-ae4c9016d76b667658c8ba66f3bbd2eebf2656af has failed.\n\nIf this error persists you could try removing the cache directory '/home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/cache/bundler/git/procon_bypass_man-ae4c9016d76b667658c8ba66f3bbd2eebf2656af'"
-  if /try removing the cache directory '([^']+)'/ =~ e.message
+  if /try removing the cache directory '([^']+)'/ =~ e.message && $1&.start_with?('/home/pi/.rbenv')
     require 'fileutils'
     FileUtils.rm_rf($1)
-    retry
+    STDOUT.puts "Deleted #{$1}"
   end
+
+  retry
 end
 
 ProconBypassMan.configure do |config|

--- a/project_template/app.rb.erb
+++ b/project_template/app.rb.erb
@@ -4,7 +4,7 @@ require 'bundler/inline'
 
 retry_count_on_git_command_error = 0
 begin
-  if retry_count_on_git_command_error > 3
+  if retry_count_on_git_command_error > 10
     STDOUT.puts "Stopped the procon_bypass_man program because could not download any source codes."
     exit 1
   end
@@ -15,7 +15,7 @@ begin
     gem 'procon_bypass_man', '0.2.1'
   end
 rescue Bundler::Source::Git::GitCommandError => e
-  retry_count_on_git_command_error =+ 1
+  retry_count_on_git_command_error = retry_count_on_git_command_error + 1
   sleep(5) # サービスの起動順によっては、まだoffline状態なので待機する
 
   # install中に強制終了するとgitの管理ファイルが不正状態になり、次のエラーが起きるので発生したらcache directoryを削除する


### PR DESCRIPTION
サービスとして登録しているときに、`/usr/share/pbm/v0.2.1` のような最新バージョンのディレクトリを意図せず削除してしまう場合がありました。