### PR TITLE
Switchからプロコンへバイパスするときにプロコンへは書き込まない

### DIFF
--- a/lib/procon_bypass_man/bypass/switch_to_procon.rb
+++ b/lib/procon_bypass_man/bypass/switch_to_procon.rb
@@ -39,7 +39,8 @@ class ProconBypassMan::Bypass::SwitchToProcon
             else
               self.bypass_value.binary.raw
             end
-          self.procon.write_nonblock(raw_data)
+          # バイブレーションを無効にしているのでおそらく書き込む必要はない
+          # self.procon.write_nonblock(raw_data)
         rescue IO::EAGAINWaitReadable
           next
         end


### PR DESCRIPTION
数秒間プロコンがハングアップするのは、プロコンに書き込んでいるから説