### PR TITLE
プロコンの読み込みを同期的にする

### DIFF
--- a/spec/lib/procon_bypass_man/bypass/procon_to_switch_spec.rb
+++ b/spec/lib/procon_bypass_man/bypass/procon_to_switch_spec.rb
@@ -15,8 +15,9 @@ describe ProconBypassMan::Bypass::ProconToSwitch do
     end
 
     before do
-      allow(instance).to receive(:start_procon_binary_thread)
-      allow(instance.procon_binary_queue).to receive(:shift) { binary }
+      bypass_value = double(:value)
+      allow(bypass_value).to receive(:binary) { ProconBypassMan::Domains::InboundProconBinary.new(binary: binary)  }
+      allow(ProconBypassMan::Bypass::BypassValue).to receive(:new) { bypass_value.as_null_object }
       allow(device).to receive(:write_nonblock)
     end
 


### PR DESCRIPTION
Switchへの書き込み自体が遅延することはほぼないので、同期的で問題なさそう。

同期的にした方が測定とチューニングがしやすい。