### PR TITLE
設定ファイルの再読み込み時もBGP#shutdownを呼び出す

### DIFF
--- a/lib/procon_bypass_man/bypass/bypass_command.rb
+++ b/lib/procon_bypass_man/bypass/bypass_command.rb
@@ -58,8 +58,8 @@ class ProconBypassMan::BypassCommand
         if $will_terminate_token
           if $will_terminate_token == WILL_TERMINATE_TOKEN::TERMINATE
             bypass.direct_connect_switch_via_bluetooth
-            process.shutdown
           end
+          process.shutdown
           break
         end
 


### PR DESCRIPTION
次のようなエラーが起きていたのを直す

```
設定ファイルの再読み込みを開始します
/home/pi/.rbenv/versions/3.1.2/lib/ruby/3.1.0/json/common.rb:216:in `initialize': no implicit conversion of nil into String (TypeError)
        from /home/pi/.rbenv/versions/3.1.2/lib/ruby/3.1.0/json/common.rb:216:in `new'
        from /home/pi/.rbenv/versions/3.1.2/lib/ruby/3.1.0/json/common.rb:216:in `parse'
        from /home/pi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/blue_green_process-0.1.3/lib/blue_green_process/master_process.rb:45:in `block (2 levels) in fork_process'
        from /home/pi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/blue_green_process-0.1.3/lib/blue_green_process/master_process.rb:43:in `loop'
        from /home/pi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/blue_green_process-0.1.3/lib/blue_green_process/master_process.rb:43:in `block in fork_process'
        from /home/pi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/blue_green_process-0.1.3/lib/blue_green_process/master_process.rb:35:in `fork'
        from /home/pi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/blue_green_process-0.1.3/lib/blue_green_process/master_process.rb:35:in `fork_process'
        from /home/pi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/blue_green_process-0.1.3/lib/blue_green_process/master_process.rb:16:in `initialize'
        from /home/pi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/blue_green_process-0.1.3/lib/blue_green_process.rb:28:in `new'
        from /home/pi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/blue_green_process-0.1.3/lib/blue_green_process.rb:28:in `new'
        from /home/pi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/procon_bypass_man-ca6cbb1d6898/lib/procon_bypass_man/bypass/bypass_command.rb:56:in `block in execute'
設定ファイルの再読み込みができました
バイパス処理を再開します
/home/pi/.rbenv/versions/3.1.2/lib/ruby/3.1.0/json/common.rb:216:in `initialize': no implicit conversion of nil into String (TypeError)
        from /home/pi/.rbenv/versions/3.1.2/lib/ruby/3.1.0/json/common.rb:216:in `new'
        from /home/pi/.rbenv/versions/3.1.2/lib/ruby/3.1.0/json/common.rb:216:in `parse'
        from /home/pi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/blue_green_process-0.1.3/lib/blue_green_process/master_process.rb:45:in `block (2 levels) in fork_process'
        from /home/pi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/blue_green_process-0.1.3/lib/blue_green_process/master_process.rb:43:in `loop'
        from /home/pi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/blue_green_process-0.1.3/lib/blue_green_process/master_process.rb:43:in `block in fork_process'
        from /home/pi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/blue_green_process-0.1.3/lib/blue_green_process/master_process.rb:35:in `fork'
        from /home/pi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/blue_green_process-0.1.3/lib/blue_green_process/master_process.rb:35:in `fork_process'
        from /home/pi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/blue_green_process-0.1.3/lib/blue_green_process/master_process.rb:15:in `initialize'
        from /home/pi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/blue_green_process-0.1.3/lib/blue_green_process.rb:28:in `new'
        from /home/pi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/blue_green_process-0.1.3/lib/blue_green_process.rb:28:in `new'
        from /home/pi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/procon_bypass_man-ca6cbb1d6898/lib/procon_bypass_man/bypass/bypass_command.rb:56:in `block in execute'
```

