### PR TITLE
プロコンから読み取ったバイナリを加工する処理のプロファイルを取る

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "timecop"
 gem "rubocop", require: false
 gem "sinatra", require: false
 gem "webrick", require: false
+gem "stackprof", require: false
 
 if Gem::Version.new(RUBY_VERSION) > Gem::Version.new("2.6.0")
   gem 'typeprof', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
+    stackprof (0.2.22)
     steep (0.47.0)
       activesupport (>= 5.1)
       language_server-protocol (>= 3.15, < 4.0)
@@ -134,6 +135,7 @@ DEPENDENCIES
   rspec
   rubocop
   sinatra
+  stackprof
   steep
   timecop
   typeprof

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,6 @@
+# benchmark
+## Processing
+プロコンから読み取ったバイナリを加工する処理
+
+* `ruby benchmarks/bypass.rb`
+* `bundle execc stackprof tmp/stackprof.dump`

--- a/benchmarks/bypass.rb
+++ b/benchmarks/bypass.rb
@@ -1,0 +1,11 @@
+require "stackprof"
+require "procon_bypass_man"
+
+# no action
+raw_binary = ["30f28100800078c77448287509550274ff131029001b0022005a0271ff191028001e00210064027cff1410280020002100000000000000000000000000000000"].pack("H*")
+binary = ProconBypassMan::Domains::InboundProconBinary.new(binary: raw_binary)
+StackProf.run(mode: :cpu, out: 'tmp/stackprof.dump') do
+  10000.times do
+    ProconBypassMan::Processor.new(binary).process
+  end
+end


### PR DESCRIPTION
```
==================================
  Mode: cpu(1000)
  Samples: 7612 (0.00% miss rate)
  GC: 6 (0.08%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      3098  (40.7%)        1166  (15.3%)     String#each_char
      6653  (87.4%)        1163  (15.3%)     Class#new
       749   (9.8%)         749   (9.8%)     String#[]
       679   (8.9%)         679   (8.9%)     String#unpack
       628   (8.3%)         628   (8.3%)     String#rjust
       614   (8.1%)         614   (8.1%)     Integer#to_s
      3301  (43.4%)         494   (6.5%)     Enumerable#map
      4668  (61.3%)         479   (6.3%)     ProconBypassMan::Procon::AnalogStick#initialize
       391   (5.1%)         385   (5.1%)     Kernel#dup
       236   (3.1%)         236   (3.1%)     Hash#initialize
      6663  (87.5%)         218   (2.9%)     ProconBypassMan::Procon#apply!
       513   (6.7%)         130   (1.7%)     ProconBypassMan::Procon::ModeRegistry.load
      2591  (34.0%)         123   (1.6%)     ProconBypassMan::Domains::Binary::Base#to_procon_reader
       229   (3.0%)         112   (1.5%)     Time.now
      2362  (31.0%)         110   (1.4%)     ProconBypassMan::ProconReader#initialize
        87   (1.1%)          87   (1.1%)     String#b
       175   (2.3%)          82   (1.1%)     ProconBypassMan::Procon::UserOperation#initialize
        40   (0.5%)          37   (0.5%)     ProconBypassMan::ButtonsSettingConfiguration.instance
        24   (0.3%)          17   (0.2%)     ProconBypassMan::Procon#current_layer_key
        66   (0.9%)          15   (0.2%)     ProconBypassMan::Procon#current_layer
       143   (1.9%)           7   (0.1%)     ProconBypassMan::Procon::ModeRegistry::Mode#initialize
         6   (0.1%)           6   (0.1%)     (sweeping)
       254   (3.3%)           5   (0.1%)     ProconBypassMan::Procon::LayerChanger#change_layer?
        42   (0.6%)           5   (0.1%)     ProconBypassMan::Procon#to_binary
       236   (3.1%)           5   (0.1%)     ProconBypassMan::OnMemoryCache#fetch
         7   (0.1%)           5   (0.1%)     ProconBypassMan::Domains::Binary::Base#raw
         5   (0.1%)           5   (0.1%)     Singleton::SingletonClassMethods#instance
         5   (0.1%)           5   (0.1%)     ProconBypassMan::Configuration::ClassMethods#cache
      7462  (98.0%)           4   (0.1%)     ProconBypassMan::Processor#process
         6   (0.1%)           4   (0.1%)     Kernel#initialize_dup
```