### PR TITLE
設定ファイルに埋め込んだ起動に必要なPBMのバージョンを読み込めるようにする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## unrelease
+* 設定ファイルに起動な必要なPBMのバージョンを表記できるようになりました
+  * https://github.com/splaplapla/procon_bypass_man/pull/238
+
 ## [0.3.4] - 2022-12-26
 * 左スティックを1回転するマクロを追加しました
     * 詳しい設定方法については docs/setting/splatoon3_rotation_left_stick.md を参照してください

--- a/lib/procon_bypass_man/buttons_setting_configuration/loader.rb
+++ b/lib/procon_bypass_man/buttons_setting_configuration/loader.rb
@@ -1,4 +1,5 @@
 require "procon_bypass_man/buttons_setting_configuration/param_normalizer"
+require "procon_bypass_man/buttons_setting_configuration/metadata_loader"
 
 module ProconBypassMan
   class ButtonsSettingConfiguration
@@ -8,6 +9,11 @@ module ProconBypassMan
       # @return [ProconBypassMan::ButtonsSettingConfiguration]
       def self.load(setting_path: )
         ProconBypassMan::ButtonsSettingConfiguration.instance.setting_path = setting_path
+
+        metadata_loader = ProconBypassMan::ButtonsSettingConfiguration::MetadataLoader.load(setting_path: setting_path)
+        if(Gem::Version.new(metadata_loader.required_pbm_version) >= Gem::Version.new(ProconBypassMan::VERSION))
+          ProconBypassMan::SendErrorCommand.execute(error: '起動中のPBMが設定ファイルのバージョンを満たしていません。設定ファイルが意図した通り動かない可能性があります。PBMのバージョンをあげてください。')
+        end
 
         ProconBypassMan::ButtonsSettingConfiguration.switch_new_context(:validation) do |new_instance|
           yaml = YAML.load_file(setting_path) or raise "読み込みに失敗しました"

--- a/lib/procon_bypass_man/buttons_setting_configuration/metadata_loader.rb
+++ b/lib/procon_bypass_man/buttons_setting_configuration/metadata_loader.rb
@@ -1,0 +1,27 @@
+module ProconBypassMan
+  class ButtonsSettingConfiguration
+    class MetadataLoader
+      EMPTY_VERSION = '0.0.0'
+
+      # @param [String] setting_path
+      # @return [MetadataLoader]
+      def self.load(setting_path: )
+        self.new(setting_path)
+      end
+
+      # @param [String] setting_path
+      def initialize(setting_path)
+        content = File.read(setting_path)
+        if(matched = content.match(/metadata-required_pbm_version: ([\d.]+)/))
+          @required_pbm_version = matched[1]
+        end
+      end
+
+      # @return [String]
+      def required_pbm_version
+        return EMPTY_VERSION unless defined?(@required_pbm_version)
+        return @required_pbm_version if @required_pbm_version
+      end
+    end
+  end
+end

--- a/spec/lib/procon_bypass_man/buttons_setting_configuration/loader_spec.rb
+++ b/spec/lib/procon_bypass_man/buttons_setting_configuration/loader_spec.rb
@@ -25,12 +25,10 @@ setting: |
   set_neutral_position 2100, 2000
 
   layer :up, mode: :manual do
-    # flip :zr, if_pressed: :zr, force_neutral: :zl
     flip :zr, if_pressed: :zr, force_neutral: :zl
     flip :zl, if_pressed: [:y, :b, :zl]
     flip :a, if_pressed: [:a]
     flip :down, if_pressed: :down
-    # disable [:up]
     macro fast_return.name, if_pressed: [:y, :b, :down]
     macro ProconBypassMan::Plugin::Splatoon2::Macro::JumpToUpKey, if_pressed: [:y, :b, :up]
     macro ProconBypassMan::Plugin::Splatoon2::Macro::JumpToRightKey, if_pressed: [:y, :b, :right]
@@ -40,16 +38,13 @@ setting: |
   end
   layer :right, mode: guruguru.name
   layer :left do
-  # flip :zr, if_pressed: :zr, force_neutral: :zl
+    # flip :zr, if_pressed: :zr, force_neutral: :zl
     remap :l, to: :zr
   end
   layer :down do
     # flip :zl
     # flip :zr, if_pressed: :zr, force_neutral: :zl, flip_interval: "1F"
     remap :l, to: :zr
-  end
-version: 1.0
-name: title1
   end
       EOH
     end
@@ -69,6 +64,59 @@ name: title1
       )
       expect(actual_layer_up).to include(:remaps=>{:l=>{:to=>[:zr]}})
       expect(actual_layer_up).to include(:left_analog_stick_caps=>[{:cap=>1100, :if_pressed=>[:zl, :a], :force_neutral=>[:a]}])
+    end
+  end
+
+  describe '.load' do
+    describe 'metadata-required_pbm_versionの読み取り' do
+      context 'metadata-required_pbm_versionの記載がない' do
+        let(:setting_content) do
+          <<~EOH
+            version: 1.0
+            setting: |
+              prefix_keys_for_changing_layer [:zr, :zl, :l]
+          EOH
+        end
+
+        it 'ProconBypassMan::SendErrorCommandを実行しない' do
+          expect(ProconBypassMan::SendErrorCommand).not_to receive(:execute).with(error: '起動中のPBMが設定ファイルのバージョンを満たしていません。設定ファイルが意図した通り動かない可能性があります。PBMのバージョンをあげてください。')
+          described_class.load(setting_path: setting.path)
+        end
+      end
+
+      context 'metadata-required_pbm_versionの記載がある' do
+        context 'metadata-required_pbm_versionが足りる' do
+          let(:setting_content) do
+            <<~EOH
+            version: 1.0
+            setting: |
+              # metadata-required_pbm_version: 0.0.0
+              prefix_keys_for_changing_layer [:zr, :zl, :l]
+            EOH
+          end
+
+          it 'ProconBypassMan::SendErrorCommandを実行しない' do
+            expect(ProconBypassMan::SendErrorCommand).not_to receive(:execute).with(error: '起動中のPBMが設定ファイルのバージョンを満たしていません。設定ファイルが意図した通り動かない可能性があります。PBMのバージョンをあげてください。')
+            described_class.load(setting_path: setting.path)
+          end
+        end
+
+        context 'metadata-required_pbm_versionが足りない' do
+          let(:setting_content) do
+            <<~EOH
+            version: 1.0
+            setting: |
+              # metadata-required_pbm_version: 9.0.0
+              prefix_keys_for_changing_layer [:zr, :zl, :l]
+            EOH
+          end
+
+          it 'ProconBypassMan::SendErrorCommandを実行する' do
+            expect(ProconBypassMan::SendErrorCommand).to receive(:execute).with(error: '起動中のPBMが設定ファイルのバージョンを満たしていません。設定ファイルが意図した通り動かない可能性があります。PBMのバージョンをあげてください。')
+            described_class.load(setting_path: setting.path)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/lib/procon_bypass_man/buttons_setting_configuration/metadata_loader_spec.rb
+++ b/spec/lib/procon_bypass_man/buttons_setting_configuration/metadata_loader_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+describe ProconBypassMan::ButtonsSettingConfiguration::MetadataLoader do
+  let(:setting) { Setting.new(setting_content).to_file }
+
+  describe '#required_pbm_version' do
+    context 'metadataの記載がない' do
+      let(:setting_content) do
+        <<~EOH
+          version: 1.0
+          setting: |
+            prefix_keys_for_changing_layer [:zr, :zl, :l]
+        EOH
+      end
+
+      it 'empty valueを返す' do
+        loader = described_class.load(setting_path: setting.path)
+        expect(loader.required_pbm_version).to eq('0.0.0')
+      end
+    end
+
+    context 'metadata required_pbm_versionの記載がある' do
+      let(:setting_content) do
+        <<~EOH
+            version: 1.0
+            setting: |
+              # metadata-required_pbm_version: 0.3.0
+              prefix_keys_for_changing_layer [:zr, :zl, :l]
+        EOH
+      end
+
+      it 'コメントから読み込む' do
+        loader = described_class.load(setting_path: setting.path)
+        expect(loader.required_pbm_version).to eq('0.3.0')
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/splaplapla/procon_bypass_man_setting_editor/pull/15 で実装したメタデータを読み込む修正です。