### PR TITLE
レイヤー変更ボタンが空欄の時に設定ファイルを有効扱いにする

### DIFF
--- a/lib/procon_bypass_man/buttons_setting_configuration/validator.rb
+++ b/lib/procon_bypass_man/buttons_setting_configuration/validator.rb
@@ -12,7 +12,7 @@ module ProconBypassMan
       def valid?
         @errors = Hash.new {|h,k| h[k] = [] }
 
-        validate_require_prefix_keys
+        warn_blank_prefix_keys
         validate_config_of_button_lonely
         validate_verify_button_existence
         validate_flip_and_remap_are_hate_each_other
@@ -56,10 +56,10 @@ module ProconBypassMan
         end
       end
 
-      def validate_require_prefix_keys
+      # @return [void]
+      def warn_blank_prefix_keys
         if @prefix_keys.empty?
-          @errors[:prefix_keys] ||= []
-          @errors[:prefix_keys] << "prefix_keys_for_changing_layerに値が入っていません。"
+          ProconBypassMan.logger.warn "prefix_keys_for_changing_layerに値が入っていません。"
         end
       end
 

--- a/spec/lib/procon_bypass_man/buttons_setting_configuration_spec.rb
+++ b/spec/lib/procon_bypass_man/buttons_setting_configuration_spec.rb
@@ -345,7 +345,7 @@ describe ProconBypassMan::ButtonsSettingConfiguration do
           )
         end
       end
-      context '設定内容が不正のとき' do
+      context 'prefix_keys_for_changing_layerが空欄のとき' do
         let(:setting_content) do
           <<~EOH
           version: 1.0
@@ -359,9 +359,7 @@ describe ProconBypassMan::ButtonsSettingConfiguration do
         it do
           expect {
             ProconBypassMan::ButtonsSettingConfiguration::Loader.load(setting_path: setting.path)
-          }.to raise_error(
-            ProconBypassMan::CouldNotLoadConfigError
-          )
+          }.not_to raise_error
         end
       end
 


### PR DESCRIPTION
何も設定せずに https://splaplapla.github.io/procon_bypass_man_setting_editor/ で出力できる設定ファイルがそのようになっているため。
それと、レイヤーupしか使わない時は、「それ」を使わないので。