### PR TITLE
PBM-Cloudと連携しているかをbootメッセージに表示する

### DIFF
--- a/lib/procon_bypass_man.rb
+++ b/lib/procon_bypass_man.rb
@@ -40,6 +40,7 @@ require_relative "procon_bypass_man/support/cycle_sleep"
 require_relative "procon_bypass_man/support/can_over_process"
 require_relative "procon_bypass_man/support/retryable"
 require_relative "procon_bypass_man/support/renice_command"
+require_relative "procon_bypass_man/support/web_connectivity_checker"
 require_relative "procon_bypass_man/procon_display"
 require_relative "procon_bypass_man/background"
 require_relative "procon_bypass_man/commands"
@@ -61,7 +62,6 @@ require_relative "procon_bypass_man/worker"
 require_relative "procon_bypass_man/websocket/client"
 require_relative "procon_bypass_man/websocket/watchdog"
 require_relative "procon_bypass_man/websocket/forever"
-
 require_relative "procon_bypass_man/remote_action"
 
 STDOUT.sync = true

--- a/lib/procon_bypass_man/commands/print_boot_message_command.rb
+++ b/lib/procon_bypass_man/commands/print_boot_message_command.rb
@@ -34,6 +34,7 @@ class ProconBypassMan::PrintBootMessageCommand
       ProconBypassMan::VERSION: #{@table[:pbm_version]}
       RUBY_VERSION: #{@table[:ruby_version]}
       Pbmenv::VERSION: #{@table[:pbmenv_version]}
+      PBM-Cloud Integration: #{ProconBypassMan::WebConnectivityChecker.new(ProconBypassMan.config.api_server)}
       pid: #{@table[:pid]}
       root: #{@table[:root_path]}
       pid_path: #{@table[:pid_path]}

--- a/lib/procon_bypass_man/support/web_connectivity_checker.rb
+++ b/lib/procon_bypass_man/support/web_connectivity_checker.rb
@@ -1,0 +1,39 @@
+class ProconBypassMan::WebConnectivityChecker
+  # @param [String, NilClass] url
+  def initialize(url)
+    @url = url
+  end
+
+  # @return [String]
+  def to_s
+    if @url.nil?
+      return "DISABLE"
+    end
+
+    if alive?
+      return "ENABLE (#{@url})"
+    else
+     return "UNREACHABLE (#{@url})"
+    end
+  end
+
+  private
+
+  # @return [Boolean]
+  def alive?
+    uri = URI.parse(@url)
+    response = nil
+
+    begin
+      Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+        request = Net::HTTP::Head.new(uri)
+        response = http.request(request)
+      end
+    rescue StandardError => e
+      ProconBypassMan.logger.error e
+      return false
+    end
+
+    response.is_a?(Net::HTTPSuccess) or response.is_a?(Net::HTTPMovedPermanently)
+  end
+end

--- a/spec/lib/procon_bypass_man/support/web_connectivity_checker_spec.rb
+++ b/spec/lib/procon_bypass_man/support/web_connectivity_checker_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+RSpec.describe ProconBypassMan::WebConnectivityChecker do
+  describe '#to_s' do
+    context 'when url is nil' do
+      it 'returns "DISABLE"' do
+        checker = ProconBypassMan::WebConnectivityChecker.new(nil)
+        expect(checker.to_s).to eq('DISABLE')
+      end
+    end
+
+    context 'when url is alive' do
+      it 'returns "ENABLE (url)"' do
+        checker = ProconBypassMan::WebConnectivityChecker.new('https://www.example.com')
+
+        http_double = instance_double('Net::HTTP')
+        allow(Net::HTTP).to receive(:start).and_yield(http_double)
+        allow(http_double).to receive(:request).and_return(Net::HTTPSuccess.new(1.0, 200, 'OK'))
+
+        expect(checker.to_s).to eq('ENABLE (https://www.example.com)')
+      end
+    end
+
+    context 'when url is unreachable' do
+      it 'returns "UNREACHABLE (url)"' do
+        checker = ProconBypassMan::WebConnectivityChecker.new('https://www.unreachable-url.com')
+
+        http_double = instance_double('Net::HTTP')
+        allow(Net::HTTP).to receive(:start).and_yield(http_double)
+        allow(http_double).to receive(:request).and_return(Net::HTTPNotFound.new(1.0, 404, 'Not Found'))
+
+        expect(checker.to_s).to eq('UNREACHABLE (https://www.unreachable-url.com)')
+      end
+    end
+  end
+end


### PR DESCRIPTION
`PBM-Cloud Integration: ENABLE (https://pbm-cloud.jiikko.com)` が表示されるようになります。

```
pi@ras1[/usr/share/pbm/current]$ sudo /home/pi/.rbenv/shims/ruby app.rb
PBMを起動しています
----
ProconBypassMan::VERSION: 0.3.6
RUBY_VERSION: 3.0.1
Pbmenv::VERSION: 0.1.11
PBM-Cloud Integration: ENABLE (https://pbm-cloud.jiikko.com)
pid: 20896
root: /usr/share/pbm/v0.3.6
pid_path: /usr/share/pbm/v0.3.6/pbm_pid
setting_path: /usr/share/pbm/current/setting.yml
uptime from boot: 75611 sec
use_pbmenv: true
session_id: s_e006aa81-d2d9-4a64-a701-30c85fed00da
device_id: d_f55d4cf3-ca*************************
----
```