### PR TITLE
method_missingの代わりにdefine_methodを使う

### DIFF
--- a/lib/procon_bypass_man/procon/button_collection.rb
+++ b/lib/procon_bypass_man/procon/button_collection.rb
@@ -37,4 +37,9 @@ class ProconBypassMan::Procon::ButtonCollection
   BUTTONS = ProconBypassMan::Procon::ButtonCollection::BUTTONS_MAP.keys.freeze
 
   LEFT_ANALOG_STICK = { byte_position: 6..8 }
+
+  # @return [Array<Symbol>]
+  def self.available
+    BUTTONS
+  end
 end

--- a/spec/support/ext/procon.rb
+++ b/spec/support/ext/procon.rb
@@ -1,11 +1,8 @@
 class ProconBypassMan::Procon
-  private
-
-  def method_missing(name)
-    if name.to_s =~ /\Apressed_[a-z]+\?\z/
-      user_operation.public_send(name)
-    else
-      super
+  ProconBypassMan::Procon::ButtonCollection.available.each do |button|
+    method_name = "pressed_#{button}?"
+    define_method(method_name) do
+      user_operation.public_send(method_name)
     end
   end
 end


### PR DESCRIPTION
method_missingだとmethods.grepで候補を絞り込めず不便なので