### PR TITLE
boot messageに有効な外部入力先を表示する

### DIFF
--- a/lib/procon_bypass_man/commands/print_boot_message_command.rb
+++ b/lib/procon_bypass_man/commands/print_boot_message_command.rb
@@ -35,6 +35,7 @@ class ProconBypassMan::PrintBootMessageCommand
       RUBY_VERSION: #{@table[:ruby_version]}
       Pbmenv::VERSION: #{@table[:pbmenv_version]}
       PBM-Cloud Integration: #{ProconBypassMan::WebConnectivityChecker.new(ProconBypassMan.config.api_server)}
+      ExternalInput Integration: #{ProconBypassMan::ExternalInput::BootMessage.new(channels: ProconBypassMan::ExternalInput.channels)}
       pid: #{@table[:pid]}
       root: #{@table[:root_path]}
       pid_path: #{@table[:pid_path]}

--- a/lib/procon_bypass_man/external_input.rb
+++ b/lib/procon_bypass_man/external_input.rb
@@ -28,3 +28,4 @@ end
 
 require "procon_bypass_man/external_input/external_data"
 require "procon_bypass_man/external_input/channels.rb"
+require "procon_bypass_man/external_input/boot_message"

--- a/lib/procon_bypass_man/external_input/boot_message.rb
+++ b/lib/procon_bypass_man/external_input/boot_message.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ProconBypassMan
+  module ExternalInput
+    class BootMessage
+      # @return [ProconBypassMan::ExternalInput::Channels::Base]
+      def initialize(channels: )
+        @channels = channels
+      end
+
+      # @return [String]
+      def to_s
+        if @channels.nil? or @channels.empty?
+          return 'DISABLE'
+        end
+
+        @channels.map(&:display_name_for_boot_message).join(', ')
+      end
+    end
+  end
+end

--- a/lib/procon_bypass_man/external_input/channels/base.rb
+++ b/lib/procon_bypass_man/external_input/channels/base.rb
@@ -7,7 +7,13 @@ module ProconBypassMan
           raise NotImplementedError
         end
 
+        # @return [void]
         def shutdown
+          raise NotImplementedError
+        end
+
+        # @return [String]
+        def display_name_for_boot_message
           raise NotImplementedError
         end
       end

--- a/lib/procon_bypass_man/external_input/channels/serial_port_channel.rb
+++ b/lib/procon_bypass_man/external_input/channels/serial_port_channel.rb
@@ -14,7 +14,7 @@ module ProconBypassMan
           data_bits = 8
           stop_bits = 1
           parity = SerialPort::NONE
-          @serial_port= SerialPort.new(device_path, baud_rate, data_bits, stop_bits, parity)
+          @serial_port = SerialPort.new(device_path, baud_rate, data_bits, stop_bits, parity)
         end
 
         # @return [String, NilClass]
@@ -45,6 +45,10 @@ module ProconBypassMan
 
         def shutdown
           # no-op
+        end
+
+        def display_name_for_boot_message
+          'SerialPort'
         end
       end
     end

--- a/lib/procon_bypass_man/external_input/channels/tcpip_channel.rb
+++ b/lib/procon_bypass_man/external_input/channels/tcpip_channel.rb
@@ -115,6 +115,10 @@ module ProconBypassMan
 
           true
         end
+
+        def display_name_for_boot_message
+          "TCPIP(port: #{@port})"
+        end
       end
     end
   end

--- a/spec/lib/procon_bypass_man/external_input/boot_message_spec.rb
+++ b/spec/lib/procon_bypass_man/external_input/boot_message_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+describe ProconBypassMan::ExternalInput::BootMessage do
+  describe '#to_s' do
+    subject { described_class.new(channels: channels).to_s }
+
+    context 'when provides []' do
+      let(:channels) { [] }
+
+      it do
+        expect(subject).to eq('DISABLE')
+      end
+    end
+
+    context 'when provides any' do
+      let(:channels) { [MockSerialPortChannel.new, MockTCPIPChannel.new] }
+
+      before do
+        stub_const('MockSerialPortChannel', Class.new(ProconBypassMan::ExternalInput::Channels::SerialPortChannel) do
+          def initialize(*args); end
+        end)
+        stub_const('MockTCPIPChannel', Class.new(ProconBypassMan::ExternalInput::Channels::TCPIPChannel) do
+          def initialize(*_args)
+            @port = 1234
+          end
+        end)
+      end
+
+      it do
+        expect(subject).to eq("SerialPort, TCPIP(port: 1234)")
+      end
+    end
+  end
+end


### PR DESCRIPTION
ex:

```
----
ProconBypassMan::VERSION: 0.3.7
RUBY_VERSION: 3.1.2
Pbmenv::VERSION: 0.1.11
PBM-Cloud Integration: DISABLE
ExternalInput Integration: DISABLE
pid: 77741
root: /tmp
pid_path: /Users/koji/src/procon_bypass_man/lib/pbm_pid
setting_path:
uptime from boot: -1 sec
use_pbmenv: true
session_id: s_2454c5f4-6957-4dc3-a8b5-e7b8f860e838
device_id: m_8f1173da-f5*************************
----
```