### PR TITLE
マクロを実行した時にメモリ使用率が増え続ける問題を修正する

### DIFF
--- a/lib/procon_bypass_man/procon.rb
+++ b/lib/procon_bypass_man/procon.rb
@@ -214,6 +214,8 @@ class ProconBypassMan::Procon
       end
       user_operation.press_button_only_or_tilt_sticks(step)
       return user_operation.binary.raw
+    else
+      BlueGreenProcess::SharedVariable.extend_run_on_this_process = false
     end
 
     current_layer.disables.each do |button|


### PR DESCRIPTION
fix https://github.com/splaplapla/procon_bypass_man/issues/271

マクロを実行すると、バイパスプロセスのスイッチ(blue green processライブラリ)を(一時的に)無効するんですが、一度無効にするとバイパスプロセスのスイッチを再び有効にするパスがなくて、 https://github.com/splaplapla/procon_bypass_man/issues/271 が起きており、メモリ使用率が増え続けるようになっていました。

本PRでは、マクロ実行後にバイパスプロセスのスイッチを再び有効にするようにします。