### PR TITLE
inline bundlerの代わりにGemfileを使うようにする

### DIFF
--- a/project_template/Gemfile
+++ b/project_template/Gemfile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
+
+gem 'procon_bypass_man', '0.3.10'
+
+# uncomment if you want to use master branch
+# gem 'procon_bypass_man', github: 'splaplapla/procon_bypass_man', branch: 'master'
+# uncomment if you want to use serial communication feature
+# gem "serialport"

--- a/project_template/app.rb
+++ b/project_template/app.rb
@@ -1,37 +1,7 @@
 #!/usr/bin/env ruby
 
-require 'bundler/inline'
-
-retry_count_on_git_command_error = 0
-begin
-  if retry_count_on_git_command_error > 10
-    STDOUT.puts "Stopped the procon_bypass_man program because could not download any source codes."
-    exit 1
-  end
-
-  gemfile do
-    source 'https://rubygems.org'
-    git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
-    gem 'procon_bypass_man', '0.3.10'
-    # uncomment if you want to use master branch
-    # gem 'procon_bypass_man', github: 'splaplapla/procon_bypass_man', branch: 'master'
-    # uncomment if you want to use serial communication feature
-    # gem "serialport"
-  end
-rescue Bundler::Source::Git::GitCommandError => e
-  retry_count_on_git_command_error = retry_count_on_git_command_error + 1
-  sleep(5) # サービスの起動順によっては、まだoffline状態なので待機する
-
-  # install中に強制終了するとgitの管理ファイルが不正状態になり、次のエラーが起きるので発生したらcache directoryを削除する
-  #"Git error: command `git fetch --force --quiet --tags https://github.com/splaplapla/procon_bypass_man refs/heads/\\*:refs/heads/\\*` in directory /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/cache/bundler/git/procon_bypass_man-ae4c9016d76b667658c8ba66f3bbd2eebf2656af has failed.\n\nIf this error persists you could try removing the cache directory '/home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/cache/bundler/git/procon_bypass_man-ae4c9016d76b667658c8ba66f3bbd2eebf2656af'"
-  if /try removing the cache directory '([^']+)'/ =~ e.message && $1&.start_with?('/home/pi/.rbenv')
-    require 'fileutils'
-    FileUtils.rm_rf($1)
-    STDOUT.puts "Deleted #{$1}"
-  end
-
-  retry
-end
+require 'bundler/setup'
+Bundler.require
 
 ProconBypassMan.configure do |config|
   config.root = File.expand_path(__dir__)

--- a/project_template/app.rb.erb
+++ b/project_template/app.rb.erb
@@ -1,37 +1,7 @@
 #!/usr/bin/env ruby
 
-require 'bundler/inline'
-
-retry_count_on_git_command_error = 0
-begin
-  if retry_count_on_git_command_error > 10
-    STDOUT.puts "Stopped the procon_bypass_man program because could not download any source codes."
-    exit 1
-  end
-
-  gemfile do
-    source 'https://rubygems.org'
-    git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
-    gem 'procon_bypass_man', '0.3.10'
-    # uncomment if you want to use master branch
-    # gem 'procon_bypass_man', github: 'splaplapla/procon_bypass_man', branch: 'master'
-    # uncomment if you want to use serial communication feature
-    # gem "serialport"
-  end
-rescue Bundler::Source::Git::GitCommandError => e
-  retry_count_on_git_command_error = retry_count_on_git_command_error + 1
-  sleep(5) # サービスの起動順によっては、まだoffline状態なので待機する
-
-  # install中に強制終了するとgitの管理ファイルが不正状態になり、次のエラーが起きるので発生したらcache directoryを削除する
-  #"Git error: command `git fetch --force --quiet --tags https://github.com/splaplapla/procon_bypass_man refs/heads/\\*:refs/heads/\\*` in directory /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/cache/bundler/git/procon_bypass_man-ae4c9016d76b667658c8ba66f3bbd2eebf2656af has failed.\n\nIf this error persists you could try removing the cache directory '/home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/cache/bundler/git/procon_bypass_man-ae4c9016d76b667658c8ba66f3bbd2eebf2656af'"
-  if /try removing the cache directory '([^']+)'/ =~ e.message && $1&.start_with?('/home/pi/.rbenv')
-    require 'fileutils'
-    FileUtils.rm_rf($1)
-    STDOUT.puts "Deleted #{$1}"
-  end
-
-  retry
-end
+require 'bundler/setup'
+Bundler.require
 
 ProconBypassMan.configure do |config|
   config.root = File.expand_path(__dir__)


### PR DESCRIPTION
fix https://github.com/splaplapla/procon_bypass_man/issues/275

起動が早くなったり安定するようになるけど、インストール手順がちょっと増える。

TODO
 - [ ] pbmenvを修正してpbmenv installを実行するとbundle installを実行するようにする
   - 旧pbmenvを使っている場合はinline bundlerを使うようにする？
 - [ ] generate_default_appを実行するとGemfileを生成するようにする
 - [ ] `bundle exec ...ruby app.rb` が起動コマンドになるけど、root権限のまま実行するにはどうするか考える
   - gemのインストール場所はpathオプションで指定したほうがいい気がする
       - root権限と一般user権限のgemが混ざる可能性があるので
   - root権限になったらbundle pathとか変わるはず
   - [ ] `sudo bundle exec`を実行するとbundle execが見えないはずなのでどうしよう