### PR TITLE
sudoをつけずにPBMを起動できるようにする2

### DIFF
--- a/lib/procon_bypass_man/device_connection/executor.rb
+++ b/lib/procon_bypass_man/device_connection/executor.rb
@@ -159,6 +159,7 @@ class ProconBypassMan::DeviceConnection::Executer
     if @initialized_devices
       return
     end
+
     ProconBypassMan::UsbDeviceController.init
     ProconBypassMan::UsbDeviceController.reset
 
@@ -171,7 +172,6 @@ class ProconBypassMan::DeviceConnection::Executer
     end
 
     begin
-      ShellRunner.execute('sudo chmod 777 -R /sys/kernel/config/usb_gadget/procon')
       ShellRunner.execute("sudo chmod 777 #{GADGET_PATH}")
       @gadget = File.open(GADGET_PATH, "w+b")
     rescue Errno::ENXIO => e

--- a/lib/procon_bypass_man/support/usb_device_controller.rb
+++ b/lib/procon_bypass_man/support/usb_device_controller.rb
@@ -46,6 +46,7 @@ class ProconBypassMan::UsbDeviceController
       EOH
 
       `sudo bash -c '#{shell}'`
+      ShellRunner.execute('sudo chmod 777 -R /sys/kernel/config/usb_gadget/procon')
     end
 
     def initialized?

--- a/lib/procon_bypass_man/support/usb_device_controller.rb
+++ b/lib/procon_bypass_man/support/usb_device_controller.rb
@@ -45,7 +45,7 @@ class ProconBypassMan::UsbDeviceController
         ls /sys/class/udc > UDC
       EOH
 
-      `bash -c '#{shell}'`
+      `sudo bash -c '#{shell}'`
     end
 
     def initialized?


### PR DESCRIPTION
usb_gadgetモードを有効にするときにsudoが足りていなかった