### PR TITLE
デバイスの接続処理を作り直す

### DIFF
--- a/lib/procon_bypass_man.rb
+++ b/lib/procon_bypass_man.rb
@@ -14,6 +14,7 @@ require "ext/module"
 require "resolv-replace"
 require "pbmenv"
 require "blue_green_process"
+require "switch_connection_manager"
 
 require_relative "procon_bypass_man/version"
 


### PR DESCRIPTION
現行実装の性質
- 通信内容を理解しなくても接続を完了できる
- https://github.com/splaplapla/procon_bypass_man/issues/168
- プロコンとスイッチの通信内容をリアルタイムにバイパスしているので、プロコンのみを再接続することができない
- プロコン実物が必要なので、プロコンなしで起動することができない

----

本PRでは、プロコンとスイッチのそれぞれと単独でコミュニケーションをして接続を行う。これによって再接続やキーマウ操作も比較的簡単にできるようになりそう。

```diff
+ gem "switch_connection_manager", github: "splaplapla/switch_connection_manager", branch: "master"
```

