### PR TITLE
ruby-2.5系のサポートをやめる

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
       - image: ruby:<< parameters.tag >>
     environment:
       BUNDLE_PATH: vendor/bundle
-      BUNDLE_JOBS: 4
+      BUNDLE_WITHOUT: development
     working_directory: ~/app
 
 commands:
@@ -27,8 +27,7 @@ commands:
             - gem-cache-v1-<< parameters.ruby-version >>-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
             - gem-cache-v1-<< parameters.ruby-version >>-{{ arch }}-{{ .Branch }}
             - gem-cache-v1
-      # NOTE: ruby2.5だとbundler2.4系に対応していないのでバージョンを固定する
-      - run: gem i bundler -v 2.3.26 && bundle install --path vendor/bundle --jobs 100 && bundle clean
+      - run: bundle install --jobs 100 --clean
       - save_cache:
           key: gem-cache-v1-<< parameters.ruby-version >>-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
@@ -115,7 +114,6 @@ build_jobs: &build_jobs
       matrix:
         parameters:
           ruby-version:
-            - "2.5.5"
             - "3.0.1"
             - "3.0.2"
             - "3.1.2"
@@ -124,7 +122,6 @@ build_jobs: &build_jobs
       matrix:
         parameters:
           ruby-version:
-            - "2.5.5"
             - "3.0.1"
             - "3.0.2"
             - "3.1.2"
@@ -133,7 +130,6 @@ build_jobs: &build_jobs
       matrix:
         parameters:
           ruby-version:
-            - "2.5.5"
             - "3.0.1"
             - "3.0.2"
             - "3.1.2"
@@ -153,7 +149,6 @@ build_jobs: &build_jobs
       matrix:
         parameters:
           ruby-version:
-            - "2.5.5"
             - "3.0.1"
             - "3.0.2"
             - "3.1.2"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ https://user-images.githubusercontent.com/1664497/171327108-f12f56a5-fc36-48da-9
 * データ通信が可能なUSBケーブル
 
 ## 必要なソフトウェア
-* ruby 2.5 以上
+* ruby 3.0 以上
 
 ## プラグイン
 * https://github.com/splaplapla/procon_bypass_man-splatoon2


### PR DESCRIPTION
3.0以上を使ってクレメンス

--------

debian12のaptでインストールできるrubyが3.1を使っていたので2.5のサポートはもういいでしょ。